### PR TITLE
DEVELOP-1566: Add logging when performing linking to trace what data the Aha! record resolved from

### DIFF
--- a/src/components/attribute/Attribute.tsx
+++ b/src/components/attribute/Attribute.tsx
@@ -19,7 +19,6 @@ export const Attribute = ({ fields, record }: AttributeProps, { identifier, sett
   const authError = error && <div>{error}</div>;
   const isLinked = [pullRequests].some((ary) => ary && ary?.length > 0);
 
-
   if (authError) {
     return (
       <aha-flex align-items="center" justify-content="space-between" gap="5px">

--- a/src/lib/fields.ts
+++ b/src/lib/fields.ts
@@ -153,16 +153,26 @@ export const BitbucketPRToPRLink = (pr: Bitbucket.PR): IExtensionFieldPullReques
  */
 export const linkPullRequest = async (pr: Bitbucket.PR) => {
   let record;
+
   if (pr.id) {
     record = await referenceToRecordFromId(pr.id.toString());
+    if (record) {
+      console.log(`Linking to ${record.referenceNum} from PR id`);
+    }
   }
 
   if (!record && pr.source.branch.name) {
     record = await referenceToRecordFromTitle(pr.source.branch.name);
+    if (record) {
+      console.log(`Linking to ${record.referenceNum} from PR branch name`);
+    }
   }
 
   if (!record && pr.title) {
     record = await referenceToRecordFromTitle(pr.title);
+    if (record) {
+      console.log(`Linking to ${record.referenceNum} from PR title`);
+    }
   }
 
   if (record) {

--- a/src/webhooks/webhook.ts
+++ b/src/webhooks/webhook.ts
@@ -30,8 +30,6 @@ const handlePullRequest = async (payload: Webhook.PullRequestPayload, action) =>
   // Make sure the MR is linked to its record.
   const record = await linkPullRequest(pr);
 
-  // Link MR to record
-  await linkPullRequestToRecord(pr, record);
   await triggerEvent('pr.update', payload, record);
   await triggerAutomation(payload, action, record);
 };


### PR DESCRIPTION
Add additonal logging to find out what data from the PR was used to figure out the Aha! record to link against.