### PR TITLE
DEVELOP-1568: Remove unnecessary fragment that causes warnings due to the key being in the wrong place

### DIFF
--- a/src/components/attribute/PullRequests.tsx
+++ b/src/components/attribute/PullRequests.tsx
@@ -11,9 +11,7 @@ export const PullRequests = ({ record, prs }: PullRequestsProps) => {
     <div className="pull-requests">
       <aha-flex direction="column" gap="3px">
         {(prs || []).map((pr, idx) => (
-          <>
-            <PullRequest key={idx} record={record} pr={pr} />
-          </>
+          <PullRequest key={idx} record={record} pr={pr} />
         ))}
       </aha-flex>
     </div>


### PR DESCRIPTION
Remove unnecessary fragment from PullRequests component that causes warnings due to the key being applied to its child