### PR TITLE
ADT-312: Don't use PR ID when matching records from Bitbucket

### DIFF
--- a/src/types/extensionFields.d.ts
+++ b/src/types/extensionFields.d.ts
@@ -11,10 +11,6 @@ declare interface IRecordExtensionFieldBranch {
   url?: string;
 }
 
-declare interface IAccountExtensionFields {
-  bitbucketPRs?: IExtensionFieldPullRequest[];
-}
-
 declare interface IExtensionFieldPullRequest {
   id: string;
   title?: string;
@@ -29,5 +25,3 @@ declare interface IExtensionFieldPullRequest {
     referenceNum: string;
   };
 }
-
-declare type IAccountExtensionField = keyof IAccountExtensionFields;


### PR DESCRIPTION
Don't store pull requests at the account level, and don't use PR ID when matching records